### PR TITLE
feat: use @wowserhq/math@0.2.0 with updated Matrix4 and Vector3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -551,9 +551,9 @@
       "dev": true
     },
     "@wowserhq/math": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@wowserhq/math/-/math-0.1.0.tgz",
-      "integrity": "sha512-bdbqXlZn4TGeocDQOc6quVqm1nKeVqYCAVaUBHq/GGyYtUushRaTk5GES8S6Z6On9KkT+L8PZ43DLvTdn5gfJw=="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@wowserhq/math/-/math-0.2.0.tgz",
+      "integrity": "sha512-Gkc4FYps6Bwqhk2+hWggCo7JKmRz6dc0a7jr6SqDQvQbD5L1A/JXDN/C3b+ptq5MfNXn4ltXzsLpAcg+c2u44w=="
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "wow"
   ],
   "dependencies": {
-    "@wowserhq/math": "0.1.0",
+    "@wowserhq/math": "0.2.0",
     "fengari": "0.1.4"
   },
   "devDependencies": {

--- a/src/math/Matrix4.mjs
+++ b/src/math/Matrix4.mjs
@@ -1,13 +1,3 @@
 import math from '@wowserhq/math';
 
-class Matrix4 extends math.Matrix4 {
-  // TODO: Remove this once new package is published
-  translate(move) {
-    this[12] = this[8]  * move[2] + this[4] * move[1] + this[0] * move[0] + this[12];
-    this[13] = this[9]  * move[2] + this[5] * move[1] + this[1] * move[0] + this[13];
-    this[14] = this[10] * move[2] + this[6] * move[1] + this[2] * move[0] + this[14];
-    return this;
-  }
-}
-
-export default Matrix4;
+export default math.Matrix4;

--- a/src/math/Vector3.mjs
+++ b/src/math/Vector3.mjs
@@ -29,14 +29,6 @@ class Vector3 extends math.Vector3 {
     this.set(other);
     return this;
   }
-
-  // TODO: Remove this once new package is published
-  setElements(x, y, z) {
-    this[0] = x;
-    this[1] = y;
-    this[2] = z;
-    return this;
-  }
 }
 
 export default Vector3;

--- a/src/ui/rendering/Renderer.mjs
+++ b/src/ui/rendering/Renderer.mjs
@@ -113,10 +113,10 @@ class Renderer {
         ]);
         const offsetX = (root.rect.minX + root.rect.maxX) * 0.5;
         const offsetY = (root.rect.minY + root.rect.maxY) * 0.5;
-        const viewMatrix = new Matrix4();
-        viewMatrix.translate([-offsetX, -offsetY, 0]);
-        projMatrix.multiply(viewMatrix).transpose();
-        gl.uniformMatrix4fv(viewProjMatrixPtr, false, projMatrix);
+        const viewProjMatrix = new Matrix4();
+        viewProjMatrix.translate([-offsetX, -offsetY, 0.0]);
+        viewProjMatrix.multiply(projMatrix).transpose();
+        gl.uniformMatrix4fv(viewProjMatrixPtr, false, viewProjMatrix);
 
         gl.useProgram(this.program);
         gl.bindVertexArray(vao);


### PR DESCRIPTION
- Drops overrides for `Vector3.prototype.setElements` and `Matrix4.prototype.translate`
- Takes into account matrix multiplication changes introduced in https://github.com/wowserhq/math/commit/faf566068350cf0480220143968a45046abcabb4