### PR TITLE
chore: update README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Wowser Client
 
+[![Join Community](https://badgen.net/badge/discord/join%20community/blue)](https://discord.gg/DeVVKVg)
 ![Version](https://badgen.net/badge/npm/n%2Fa/gray)
 [![MIT License](https://badgen.net/github/license/wowserhq/client)](LICENSE)
 [![CI](https://github.com/wowserhq/client/workflows/CI/badge.svg)](https://github.com/wowserhq/client/actions?query=workflow%3ACI)
-[![Join chat](https://badgen.net/badge/gitter/join%20chat/red)](https://gitter.im/wowserhq/wowser)
 [![Test Coverage](https://codecov.io/gh/wowserhq/client/branch/master/graph/badge.svg)](https://codecov.io/gh/wowserhq/client)
 
 World of Warcraft in the browser using JavaScript and WebGL.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Wowser Client
 
-![Node Version](https://badgen.net/badge/node/12+/green)
 [![MIT License](https://badgen.net/github/license/wowserhq/client)](LICENSE.md)
 ![Checks](https://badgen.net/github/checks/wowserhq/client)
 [![Join chat](https://badgen.net/badge/gitter/join%20chat/red)](https://gitter.im/wowserhq/wowser)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Wowser Client
 
-[![MIT License](https://badgen.net/github/license/wowserhq/client)](LICENSE.md)
+[![MIT License](https://badgen.net/github/license/wowserhq/client)](LICENSE)
 ![Checks](https://badgen.net/github/checks/wowserhq/client)
 [![Join chat](https://badgen.net/badge/gitter/join%20chat/red)](https://gitter.im/wowserhq/wowser)
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ developed with [webpack].
    git clone git://github.com/wowserhq/wowser.git
    ```
 
-2. Download and install [Node.js] – including `npm` – for your platform.
+2. Download and install [Node.js] 12+ for your platform.
 
 3. Install dependencies:
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ World of Warcraft in the browser using JavaScript and WebGL.
 
 This repository contains the web client.
 
-Licensed under the [**MIT** license](LICENSE).
-
 ## Background
 
 Wowser is a proof-of-concept of getting a triple-A game to run in a webbrowser.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![MIT License](https://badgen.net/github/license/wowserhq/client)](LICENSE)
 [![CI](https://github.com/wowserhq/client/workflows/CI/badge.svg)](https://github.com/wowserhq/client/actions?query=workflow%3ACI)
 [![Join chat](https://badgen.net/badge/gitter/join%20chat/red)](https://gitter.im/wowserhq/wowser)
+[![Test Coverage](https://codecov.io/gh/wowserhq/client/branch/master/graph/badge.svg)](https://codecov.io/gh/wowserhq/client)
 
 World of Warcraft in the browser using JavaScript and WebGL.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Wowser Client
 
+![Version](https://badgen.net/badge/npm/n%2Fa/gray)
 [![MIT License](https://badgen.net/github/license/wowserhq/client)](LICENSE)
 [![CI](https://github.com/wowserhq/client/workflows/CI/badge.svg)](https://github.com/wowserhq/client/actions?query=workflow%3ACI)
 [![Join chat](https://badgen.net/badge/gitter/join%20chat/red)](https://gitter.im/wowserhq/wowser)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Wowser Client
 
 [![MIT License](https://badgen.net/github/license/wowserhq/client)](LICENSE)
-![Checks](https://badgen.net/github/checks/wowserhq/client)
+[![CI](https://github.com/wowserhq/client/workflows/CI/badge.svg)](https://github.com/wowserhq/client/actions?query=workflow%3ACI)
 [![Join chat](https://badgen.net/badge/gitter/join%20chat/red)](https://gitter.im/wowserhq/wowser)
 
 World of Warcraft in the browser using JavaScript and WebGL.


### PR DESCRIPTION
- Normalizes Discord, GitHub CI and code coverage badges.
- Drops the Node version badge (but mentions the minimum version in text a bit further down)
- Adds a dummy npm version badge (as we lack a release for the time being)

README preview: https://github.com/wowserhq/client/blob/eccc1669b67bdb8d855bfddc320267e106c8e75c/README.md