### PR TITLE
fix: silence TypeScript complaining about unresolved lua file imports

### DIFF
--- a/src/ui/scripting/ScriptingContext.ts
+++ b/src/ui/scripting/ScriptingContext.ts
@@ -33,8 +33,8 @@ import {
   to_luastring,
 } from './lua';
 
-import bitLua from './vendor/bit.lua';
-import compatLua from './vendor/compat.lua';
+import bitLua from './vendor/bit.lua?raw'; // eslint-disable-line import/no-unresolved
+import compatLua from './vendor/compat.lua?raw'; // eslint-disable-line import/no-unresolved
 
 import FrameScriptObject from './FrameScriptObject';
 

--- a/vendor/global.d.ts
+++ b/vendor/global.d.ts
@@ -1,5 +1,5 @@
 // Ensures `import file from './file.lua'` does not trip up TypeScript compiler
-declare module '*.lua' {
+declare module '*.lua?raw' {
   const format: string;
   export default format;
 }


### PR DESCRIPTION
Silences `Cannot find module './vendor/compat.lua' or its corresponding type declarations. ts(2307)`