### PR TITLE
fix: handling of enums with value 0

### DIFF
--- a/src/ui/components/abstract/FramePointType.ts
+++ b/src/ui/components/abstract/FramePointType.ts
@@ -10,12 +10,7 @@ enum FramePointType {
   BOTTOMRIGHT = 8,
 }
 
-export const stringToPointType = (string?: string) => {
-  if (!string) return undefined;
-  return FramePointType[string.toUpperCase() as keyof typeof FramePointType];
-};
-
-export const FramePointTypeSide = {
+const FramePointTypeSide = {
   CENTERX: [
     FramePointType.TOP,
     FramePointType.CENTER,
@@ -49,3 +44,4 @@ export const FramePointTypeSide = {
 };
 
 export default FramePointType;
+export { FramePointTypeSide };

--- a/src/ui/components/abstract/LayoutFrame.ts
+++ b/src/ui/components/abstract/LayoutFrame.ts
@@ -1,5 +1,6 @@
 import ScriptRegion from './ScriptRegion';
 import XMLNode from '../../XMLNode';
+import { stringToFramePointType } from '../../utils';
 import {
   EPSILON1,
   EPSILON2,
@@ -18,10 +19,7 @@ import {
 } from '../../../utils';
 
 import FramePoint from './FramePoint';
-import FramePointType, {
-  FramePointTypeSide,
-  stringToPointType,
-} from './FramePointType';
+import FramePointType, { FramePointTypeSide } from './FramePointType';
 
 class FrameNode extends LinkedListNode {
   frame: LayoutFrame;
@@ -397,16 +395,16 @@ class LayoutFrame {
         const relativePointValue = child.attributes.get('relativePoint');
         const relativeValue = child.attributes.get('relativeTo');
 
-        const pointType = stringToPointType(pointValue);
+        const pointType = stringToFramePointType(pointValue);
         let relativePointType = pointType;
-        if (!pointType) {
+        if (pointType === undefined) {
           // TODO: Error handling
           continue;
         }
 
         if (relativePointValue) {
-          relativePointType = stringToPointType(relativePointValue);
-          if (!relativePointType) {
+          relativePointType = stringToFramePointType(relativePointValue);
+          if (relativePointType === undefined) {
             // TODO: Error handling
             continue;
           }

--- a/src/ui/components/simple/Frame.ts
+++ b/src/ui/components/simple/Frame.ts
@@ -19,7 +19,7 @@ import {
 import { Rect } from '../../../math';
 import {
   stringToDrawLayerType,
-  stringToStrataType,
+  stringToFrameStrataType,
 } from '../../utils';
 
 import FrameFlag from './FrameFlag';
@@ -308,8 +308,8 @@ class Frame extends ScriptRegion {
     }
 
     if (frameStrata) {
-      const strataType = stringToStrataType(frameStrata);
-      if (strataType) {
+      const strataType = stringToFrameStrataType(frameStrata);
+      if (strataType !== undefined) {
         this.setFrameStrataType(strataType);
       } else {
         // TODO: Error handling
@@ -371,8 +371,7 @@ class Frame extends ScriptRegion {
 
       const level = layer.attributes.get('level');
 
-      // TODO: Case sensitivity
-      const drawLayerType = stringToDrawLayerType(level) || DrawLayerType.ARTWORK;
+      const drawLayerType = stringToDrawLayerType(level) ?? DrawLayerType.ARTWORK;
 
       for (const layerChild of layer.children) {
         const iname = layerChild.name.toLowerCase();

--- a/src/ui/components/simple/Texture.ts
+++ b/src/ui/components/simple/Texture.ts
@@ -240,7 +240,7 @@ class Texture extends Region {
 
     if (alphaMode) {
       const blendMode = stringToBlendMode(alphaMode);
-      if (blendMode) {
+      if (blendMode !== undefined) {
         this.setBlendMode(blendMode);
       }
     }

--- a/src/ui/utils.ts
+++ b/src/ui/utils.ts
@@ -1,6 +1,7 @@
 import { BlendMode } from '../gfx/types';
 
 import DrawLayerType from './DrawLayerType';
+import FramePointType from './components/abstract/FramePointType';
 import FrameStrataType from './components/abstract/FrameStrataType';
 
 export const stringToBlendMode = (string?: string) => {
@@ -13,7 +14,12 @@ export const stringToDrawLayerType = (string?: string) => {
   return DrawLayerType[string?.toUpperCase() as keyof typeof DrawLayerType];
 };
 
-export const stringToStrataType = (string?: string) => {
+export const stringToFramePointType = (string?: string) => {
+  if (!string) return undefined;
+  return FramePointType[string.toUpperCase() as keyof typeof FramePointType];
+};
+
+export const stringToFrameStrataType = (string?: string) => {
   if (!string) return undefined;
   return FrameStrataType[string?.toUpperCase() as keyof typeof FrameStrataType];
 };


### PR DESCRIPTION
Something ala `if (!pointType)` is not sufficient when `FramePointType.TOPLEFT` is `0` 🙈 